### PR TITLE
🚑 Ignore trailing newline when sorting file

### DIFF
--- a/lib/range-finder.coffee
+++ b/lib/range-finder.coffee
@@ -13,7 +13,7 @@ class RangeFinder
   ranges: ->
     selectionRanges = @selectionRanges()
     if selectionRanges.length is 0
-      [@sortableRangeForEntireBuffer()]
+      [@sortableRangeFrom(@sortableRangeForEntireBuffer())]
     else
       selectionRanges.map (selectionRange) =>
         @sortableRangeFrom(selectionRange)

--- a/spec/sort-lines-spec.coffee
+++ b/spec/sort-lines-spec.coffee
@@ -38,6 +38,23 @@ describe "sorting lines", ->
           Lithium
         """
 
+    it "sorts all lines, ignoring the trailing new line", ->
+      editor.setText """
+        Hydrogen
+        Helium
+        Lithium
+
+      """
+      editor.setCursorBufferPosition([0, 0])
+
+      sortLines ->
+        expect(editor.getText()).toBe """
+          Helium
+          Hydrogen
+          Lithium
+
+        """
+
   describe "when entire lines are selected", ->
     it "sorts the selected lines", ->
       editor.setText """


### PR DESCRIPTION
Fixes #4
Selected ranges are "cleaned" with @sortableRangeFrom. We didn't do this when the selected range was the entire file, so I changed to do so in that case as well.
