### PR TITLE
Fix case-insensitive sort typo

### DIFF
--- a/menus/sort-lines.cson
+++ b/menus/sort-lines.cson
@@ -7,7 +7,7 @@
         { 'label': 'Sort', 'command': 'sort-lines:sort' }
         { 'label': 'Reverse Sort', 'command': 'sort-lines:reverse-sort' }
         { 'label': 'Unique', 'command': 'sort-lines:unique' }
-        { 'label': 'Sort (Case Insentivive)', 'command': 'sort-lines:case-insensitive-sort' }
+        { 'label': 'Sort (Case Insensitive)', 'command': 'sort-lines:case-insensitive-sort' }
       ]
     ]
   }


### PR DESCRIPTION
"Insensitive" was misspelled in the original menu spec.
