### PR TITLE
Adding key bindings to readme, ref #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,14 @@
 Sorts your lines in Atom, never gets tired.
 
 ![sort-lines-demo](https://f.cloud.github.com/assets/2988/1796891/85e69ff2-6a93-11e3-89ac-31927f604592.gif)
+
+## Key Mappings
+
+By default, `f5` will be bound to the `sort-lines:sort` command, which is case sensitive.
+
+To bid it to case-insensitive sort instead, edit your keymap file (see *Settings* > *Keybindings*) and add the following:
+
+```
+'atom-text-editor':
+  'f5': 'sort-lines:case-insensitive-sort'
+```


### PR DESCRIPTION
I had some trouble working this out when first installing the package, and didn't realise case insensitive sort (which is Sublime Text's default) was implemented until I found #8.

Seems like a good thing to document in the readme.
