### PR TITLE
Remove controversial default keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,18 @@
 Sorts your lines in Atom, never gets tired.
 
 ![sort-lines-demo](https://f.cloud.github.com/assets/2988/1796891/85e69ff2-6a93-11e3-89ac-31927f604592.gif)
+
+### Commands and Keybindings
+
+All of the following commands are under the `atom-text-editor` selector.
+
+If any lines are selected in the active buffer, the commands operate on the selected lines. Otherwise, the commands operate on all lines in the active buffer.
+
+|Command|Description|
+|-------|-----------|
+|`sort-lines:sort`|Sorts the lines (case sensitive)|
+|`sort-lines:case-insensitive-sort`|Sorts the lines (case insensitive)|
+|`sort-lines:reverse-sort`|Sorts the lines in reverse order (case sensitive)|
+|`sort-lines:unique`|Removes duplicate lines|
+
+You may want to use keyboard shortcuts for triggering the above commands. This package does not provide keyboard shortcuts by default, but you can easily [define your own](https://atom.io/docs/latest/using-atom-basic-customization#customizing-key-bindings). To learn more, visit the [Using Atom: Basic Customization](https://atom.io/docs/latest/using-atom-basic-customization#customizing-key-bindings) or [Behind Atom: Keymaps In-Depth](https://atom.io/docs/latest/behind-atom-keymaps-in-depth) sections in the flight manual.

--- a/keymaps/sort-lines.cson
+++ b/keymaps/sort-lines.cson
@@ -1,2 +1,0 @@
-'atom-text-editor:not([mini])':
-  'f5': 'sort-lines:sort'


### PR DESCRIPTION
Closes #31.

--

To address the concerns expressed in #31, this pull request:

- Remove the `F5` keybinding.
- Updates the README to document all available commands and explain how to define a custom keybinding that suits the package consumer. /cc https://github.com/atom/sort-lines/pull/34#issuecomment-126228699

/cc @izuzak for review
