### PR TITLE
Added Support for Files with CRLF Line Endings

### DIFF
--- a/lib/sort-lines.coffee
+++ b/lib/sort-lines.coffee
@@ -22,7 +22,7 @@ module.exports =
 sortTextLines = (editor, sorter) ->
   sortableRanges = RangeFinder.rangesFor(editor)
   sortableRanges.forEach (range) ->
-    textLines = editor.getTextInBufferRange(range).split("\n")
+    textLines = editor.getTextInBufferRange(range).split(/\r?\n/g)
     textLines = sorter(textLines)
     editor.setTextInBufferRange(range, textLines.join("\n"))
 

--- a/spec/sort-lines-spec.coffee
+++ b/spec/sort-lines-spec.coffee
@@ -184,6 +184,14 @@ describe "sorting lines", ->
           Lithium
         """
 
+    it "uniques all lines using CRLF line-endings", ->
+      editor.setText "Hydrogen\r\nHydrogen\r\nHelium\r\nLithium\r\nHydrogen\r\nHydrogen\r\nHelium\r\nLithium\r\nHydrogen\r\nHydrogen\r\nHelium\r\nLithium\r\nHydrogen\r\nHydrogen\r\nHelium\r\nLithium\r\n"
+
+      editor.setCursorBufferPosition([0,0])
+
+      uniqueLines ->
+        expect(editor.getText()).toBe "Hydrogen\r\nHelium\r\nLithium\r\n"
+
   describe "case-insensitive sorting", ->
     it "sorts all lines, ignoring case", ->
       editor.setText """


### PR DESCRIPTION
**Resolves Issue:** #51 

Previously `textLines` was only split using `"\n"` which caused `uniqueLines`
to ignore the last line when the file used CRLF line endings.

- Splitting on `"\n"` or `"\r\n"` will allow both LF and CRLF to work.
- Added a spec case to check for CRLF support.

Line endings will remain in their original format after modifications.