### PR TITLE
Support sorting words within selection(s)

### DIFF
--- a/lib/range-finder.coffee
+++ b/lib/range-finder.coffee
@@ -3,20 +3,20 @@
 module.exports =
 class RangeFinder
   # Public
-  @rangesFor: (editor) ->
-    new RangeFinder(editor).ranges()
+  @rangesFor: (editor, fullLines = true) ->
+    new RangeFinder(editor).ranges(fullLines)
 
   # Public
   constructor: (@editor) ->
 
   # Public
-  ranges: ->
+  ranges: (fullLines = true) ->
     selectionRanges = @selectionRanges()
-    if selectionRanges.length is 0
-      [@sortableRangeFrom(@sortableRangeForEntireBuffer())]
+    if fullLines and selectionRanges.length is 0
+      [@sortableRangeFrom(@sortableRangeForEntireBuffer(), fullLines)]
     else
       selectionRanges.map (selectionRange) =>
-        @sortableRangeFrom(selectionRange)
+        @sortableRangeFrom(selectionRange, fullLines)
 
   # Internal
   selectionRanges: ->
@@ -28,13 +28,18 @@ class RangeFinder
     @editor.getBuffer().getRange()
 
   # Internal
-  sortableRangeFrom: (selectionRange) ->
+  sortableRangeFrom: (selectionRange, fullLines) ->
     startRow = selectionRange.start.row
-    startCol = 0
-    endRow = if selectionRange.end.column == 0
-      selectionRange.end.row - 1
+    startCol = if fullLines then 0 else selectionRange.start.column
+
+    if selectionRange.end.column == 0
+      endRow = selectionRange.end.row - 1
+      endCol = @editor.lineTextForBufferRow(endRow).length
     else
-      selectionRange.end.row
-    endCol = @editor.lineTextForBufferRow(endRow).length
+      endRow = selectionRange.end.row
+      endCol = if fullLines
+        @editor.lineTextForBufferRow(endRow).length
+      else
+        selectionRange.end.column
 
     new Range [startRow, startCol], [endRow, endCol]

--- a/lib/sort-lines.coffee
+++ b/lib/sort-lines.coffee
@@ -18,6 +18,9 @@ module.exports =
       'sort-lines:natural': ->
         editor = atom.workspace.getActiveTextEditor()
         sortLinesNatural(editor)
+      'sort-lines:sort-words': ->
+        editor = atom.workspace.getActiveTextEditor()
+        sortWords(editor)
 
 sortTextLines = (editor, sorter) ->
   sortableRanges = RangeFinder.rangesFor(editor)
@@ -53,3 +56,10 @@ sortLinesNatural = (editor) ->
       return (if aLeadingNum < bLeadingNum then -1 else 1) if aLeadingNum isnt bLeadingNum
       return (if aTrailingNum < bTrailingNum then -1 else 1) if aTrailingNum isnt bTrailingNum
       return 0
+
+sortWords = (editor) ->
+  sortableRanges = RangeFinder.rangesFor(editor, false)
+  sortableRanges.forEach (range) ->
+    words = editor.getTextInBufferRange(range).trim().split(/\s+/g)
+    words.sort (a, b) -> a.localeCompare(b)
+    editor.setTextInBufferRange(range, words.join(" "))

--- a/menus/sort-lines.cson
+++ b/menus/sort-lines.cson
@@ -12,4 +12,13 @@
       ]
     ]
   }
+  {
+    'label': 'Edit'
+    'submenu': [
+      'label': 'Text'
+      'submenu': [
+        { 'label': 'Sort words', 'command': 'sort-lines:sort-words' }
+      ]
+    ]
+  }
 ]

--- a/menus/sort-lines.cson
+++ b/menus/sort-lines.cson
@@ -8,7 +8,7 @@
         { 'label': 'Reverse Sort', 'command': 'sort-lines:reverse-sort' }
         { 'label': 'Unique', 'command': 'sort-lines:unique' }
         { 'label': 'Sort (Case Insensitive)', 'command': 'sort-lines:case-insensitive-sort' }
-        { 'label': 'Natural', 'command': 'sort-lines:natural' }
+        { 'label': 'Sort (Natural)', 'command': 'sort-lines:natural' }
       ]
     ]
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
       "sort-lines:reverse-sort",
       "sort-lines:unique",
       "sort-lines:case-insensitive-sort",
-      "sort-lines:natural"
+      "sort-lines:natural",
+      "sort-lines:sort-words"
     ]
   },
   "repository": "https://github.com/atom/sort-lines",

--- a/spec/sort-lines-spec.coffee
+++ b/spec/sort-lines-spec.coffee
@@ -27,6 +27,11 @@ describe "sorting lines", ->
     waitsForPromise -> activationPromise
     runs(callback)
 
+  sortWords = (callback) ->
+    atom.commands.dispatch editorView, "sort-lines:sort-words"
+    waitsForPromise -> activationPromise
+    runs(callback)
+
   beforeEach ->
     waitsForPromise ->
       atom.workspace.open()
@@ -67,6 +72,21 @@ describe "sorting lines", ->
           Helium
           Hydrogen
           Lithium
+
+        """
+
+    it "does not sort words", ->
+      editor.setText """
+        d e f
+        a
+
+      """
+      editor.setCursorBufferPosition([0, 0])
+
+      sortWords ->
+        expect(editor.getText()).toBe """
+          d e f
+          a
 
         """
 
@@ -324,4 +344,38 @@ describe "sorting lines", ->
         a003
         a01
         a02
+        """
+
+  describe "word sorting", ->
+    it "sorts all selected words", ->
+      editor.setText """
+        Duh a crazy b Foo e
+        not selected and therefore should not be sorted
+      """
+      editor.addSelectionForBufferRange([[0, 0], [1, 0]])
+
+      sortWords ->
+        expect(editor.getText()).toBe """
+          a b crazy Duh e Foo
+          not selected and therefore should not be sorted
+        """
+
+    it "sorts partially selected line", ->
+      editor.setText "Duh a crazy b Foo e"
+      editor.addSelectionForBufferRange([[0, 0], [0, "Duh a crazy".length]])
+
+      sortWords ->
+        expect(editor.getText()).toBe "a crazy Duh b Foo e"
+
+    it "strips leading/trailing whitespace and joins words with one space", ->
+      editor.setText """
+        \t a c D   E\tF b \t\t
+        not selected and therefore should not be sorted
+      """
+      editor.addSelectionForBufferRange([[0, 0], [1, 0]])
+
+      sortWords ->
+        expect(editor.getText()).toBe """
+          a b c D E F
+          not selected and therefore should not be sorted
         """


### PR DESCRIPTION
I thought everything related to sorting might be a good feature for this core package, so I added a "sort words" feature.

Example: `git nginx curl` would be sorted to `curl git nginx`