### PR TITLE
Add sorting for CSS rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/lib/sort-lines.coffee
+++ b/lib/sort-lines.coffee
@@ -58,8 +58,15 @@ sortLinesNatural = (editor) ->
       return 0
 
 sortLinesCss = (editor) ->
+  normalize = (s) ->
+    s
+    # compare properties, not values
+    .split(':')[0]
+    # ignore white-space
+    .trim()
+    # push location-specific properties after general ones
+    .replace(/-(bottom|left|right|top)/, '-zz-$1')
+
   sortTextLines editor, (textLines) ->
     textLines.sort (a, b) ->
-      a = a.split(':')[0].trim()
-      b = b.split(':')[0].trim()
-      return a.localeCompare(b)
+      return normalize(a).localeCompare(normalize(b))

--- a/lib/sort-lines.coffee
+++ b/lib/sort-lines.coffee
@@ -18,6 +18,9 @@ module.exports =
       'sort-lines:natural': ->
         editor = atom.workspace.getActiveTextEditor()
         sortLinesNatural(editor)
+      'sort-lines:css': ->
+        editor = atom.workspace.getActiveTextEditor()
+        sortLinesCss(editor)
 
 sortTextLines = (editor, sorter) ->
   sortableRanges = RangeFinder.rangesFor(editor)
@@ -53,3 +56,10 @@ sortLinesNatural = (editor) ->
       return (if aLeadingNum < bLeadingNum then -1 else 1) if aLeadingNum isnt bLeadingNum
       return (if aTrailingNum < bTrailingNum then -1 else 1) if aTrailingNum isnt bTrailingNum
       return 0
+
+sortLinesCss = (editor) ->
+  sortTextLines editor, (textLines) ->
+    textLines.sort (a, b) ->
+      a = a.split(':')[0].trim()
+      b = b.split(':')[0].trim()
+      return a.localeCompare(b)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
       "sort-lines:reverse-sort",
       "sort-lines:unique",
       "sort-lines:case-insensitive-sort",
-      "sort-lines:natural"
+      "sort-lines:natural",
+      "sort-lines:css"
     ]
   },
   "repository": "https://github.com/atom/sort-lines",

--- a/spec/sort-lines-spec.coffee
+++ b/spec/sort-lines-spec.coffee
@@ -347,3 +347,23 @@ describe "sorting lines", ->
           border-bottom: 2px dashed #000;
           border-top-width: 5px;
         """
+
+    it "sorts locations after general rules", ->
+      editor.setText """
+        border-width: 1px;
+        border-style: solid;
+        border-top-width: 5px;
+        border-bottom: 2px dashed #000;
+        border-color: #fff;
+      """
+
+      editor.setCursorBufferPosition([0, 0])
+
+      sortLinesCss ->
+        expect(editor.getText()).toBe """
+          border-color: #fff;
+          border-style: solid;
+          border-width: 1px;
+          border-bottom: 2px dashed #000;
+          border-top-width: 5px;
+        """

--- a/spec/sort-lines-spec.coffee
+++ b/spec/sort-lines-spec.coffee
@@ -27,6 +27,11 @@ describe "sorting lines", ->
     waitsForPromise -> activationPromise
     runs(callback)
 
+  sortLinesCss = (callback) ->
+    atom.commands.dispatch editorView, "sort-lines:css"
+    waitsForPromise -> activationPromise
+    runs(callback)
+
   beforeEach ->
     waitsForPromise ->
       atom.workspace.open()
@@ -324,4 +329,21 @@ describe "sorting lines", ->
         a003
         a01
         a02
+        """
+
+  describe "CSS sorting", ->
+    it "sorts longhands after shorthands", ->
+      editor.setText """
+        border: 1px solid #fff;
+        border-top-width: 5px;
+        border-bottom: 2px dashed #000;
+      """
+
+      editor.setCursorBufferPosition([0, 0])
+
+      sortLinesCss ->
+        expect(editor.getText()).toBe """
+          border: 1px solid #fff;
+          border-bottom: 2px dashed #000;
+          border-top-width: 5px;
         """


### PR DESCRIPTION
This is needed for sorting CSS/less/SCSS files. In those files it is important to have e.g. `border-bottom` after `border` in order to have the more specific rule override the more general one.