### PR TITLE
Unique lines and count them.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ If any lines are selected in the active buffer, the commands operate on the sele
 |`sort-lines:natural`|Sorts the lines (["natural" order](https://en.wikipedia.org/wiki/Natural_sort_order))|
 |`sort-lines:reverse-sort`|Sorts the lines in reverse order (case sensitive)|
 |`sort-lines:unique`|Removes duplicate lines|
+|`sort-lines:unique-count`|Removes duplicate lines and write the number of occurences next to them|
 
 Custom keybindings can be added by referencing the above commands.  To learn more, visit the [Using Atom: Basic Customization](http://flight-manual.atom.io/using-atom/sections/basic-customization/#customizing-keybindings) or [Behind Atom: Keymaps In-Depth](http://flight-manual.atom.io/behind-atom/sections/keymaps-in-depth) sections in the flight manual.

--- a/lib/sort-lines.coffee
+++ b/lib/sort-lines.coffee
@@ -38,6 +38,18 @@ uniqueLines = (editor) ->
   sortTextLines editor, (textLines) ->
     textLines.filter (value, index, self) -> self.indexOf(value) == index
 
+uniqueCountLines = (editor) ->
+  sortTextLines editor, (textLines) ->
+    textLines = textLines.reduce (acc, cur, ind) ->
+      if !acc.hasOwnProperty(cur)
+        acc[cur] = 0
+      acc[cur] += 1
+      return acc
+    ,{}
+    newLines = []
+    newLines.push index + ' - ' + line for index,line of textLines
+    newLines
+
 sortLinesInsensitive = (editor) ->
   sortTextLines editor, (textLines) ->
     textLines.sort (a, b) -> a.toLowerCase().localeCompare(b.toLowerCase())

--- a/lib/sort-lines.coffee
+++ b/lib/sort-lines.coffee
@@ -12,6 +12,9 @@ module.exports =
       'sort-lines:unique': ->
         editor = atom.workspace.getActiveTextEditor()
         uniqueLines(editor)
+      'sort-lines:unique-count': ->
+        editor = atom.workspace.getActiveTextEditor()
+        uniqueCountLines(editor)
       'sort-lines:case-insensitive-sort': ->
         editor = atom.workspace.getActiveTextEditor()
         sortLinesInsensitive(editor)

--- a/menus/sort-lines.cson
+++ b/menus/sort-lines.cson
@@ -7,6 +7,7 @@
         { 'label': 'Sort', 'command': 'sort-lines:sort' }
         { 'label': 'Reverse Sort', 'command': 'sort-lines:reverse-sort' }
         { 'label': 'Unique', 'command': 'sort-lines:unique' }
+        { 'label': 'Unique Count', 'command': 'sort-lines:unique-count' }
         { 'label': 'Sort (Case Insensitive)', 'command': 'sort-lines:case-insensitive-sort' }
         { 'label': 'Natural', 'command': 'sort-lines:natural' }
       ]

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
       "sort-lines:sort",
       "sort-lines:reverse-sort",
       "sort-lines:unique",
+      "sort-lines:unique-count",
       "sort-lines:case-insensitive-sort",
       "sort-lines:natural"
     ]

--- a/spec/sort-lines-spec.coffee
+++ b/spec/sort-lines-spec.coffee
@@ -17,6 +17,11 @@ describe "sorting lines", ->
     waitsForPromise -> activationPromise
     runs(callback)
 
+  uniqueCountLines = (callback) ->
+    atom.commands.dispatch editorView, "sort-lines:unique-count"
+    waitsForPromise -> activationPromise
+    runs(callback)
+
   sortLineCaseInsensitive = (callback) ->
     atom.commands.dispatch editorView, "sort-lines:case-insensitive-sort"
     waitsForPromise -> activationPromise
@@ -191,6 +196,44 @@ describe "sorting lines", ->
 
       uniqueLines ->
         expect(editor.getText()).toBe "Hydrogen\r\nHelium\r\nLithium\r\n"
+
+  describe "uniqueing count", ->
+    it "uniques all lines and prints the amount next to them", ->
+      editor.setText """
+        Hydrogen
+        Hydrogen
+        Helium
+        Lithium
+        Hydrogen
+        Hydrogen
+        Helium
+        Lithium
+        Hydrogen
+        Hydrogen
+        Helium
+        Lithium
+        Hydrogen
+        Hydrogen
+        Helium
+        Lithium
+      """
+
+      editor.setCursorBufferPosition([0, 0])
+
+      uniqueCountLines ->
+        expect(editor.getText()).toBe """
+          Hydrogen - 8
+          Helium - 4
+          Lithium - 4
+        """
+
+    it "uniques all lines and prints amount of lines next to them using CRLF line-endings", ->
+      editor.setText "Hydrogen\r\nHydrogen\r\nHelium\r\nLithium\r\nHydrogen\r\nHydrogen\r\nHelium\r\nLithium\r\nHydrogen\r\nHydrogen\r\nHelium\r\nLithium\r\nHydrogen\r\nHydrogen\r\nHelium\r\nLithium\r\n"
+
+      editor.setCursorBufferPosition([0,0])
+
+      uniqueCountLines ->
+        expect(editor.getText()).toBe "Hydrogen - 8\r\nHelium - 4\r\nLithium - 4\r\n"
 
   describe "case-insensitive sorting", ->
     it "sorts all lines, ignoring case", ->


### PR DESCRIPTION
Hello!

I'm not sure if this is within the scope of the package.
it happens often to me, that I do statistics within atom. So my typical workflow is to filter the lines and then count the occurrences.
So what I would love to have, is to have a command to reduce all values to their unique lines (lines.filter()) but also put the occurrences behind the result.
So for example, this:

```
1
1
2
2
2
3
8
8
```

turns into this:

```
1 - 2
2 - 3
3 - 1
8 - 2
```

**Disclaimer:**
This is my first time writing tests for a package - please help me to point out if there is something wrong with it.
Also, I'm used to write ES6 JS, this is also the first time using coffeescript for me.

Thank you.