### PR TITLE
Update README with installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Sorts your lines in Atom, never gets tired.
 
 ### Installation
 
-From GUI: Settings -> Install -> search for "sort-lines" and click "Install"
+From within Atom: Settings -> Install -> search for "sort-lines" and click "Install" OR
 
 From CLI: `apm install sort-lines` and restart Atom.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Sorts your lines in Atom, never gets tired.
 
 ![sort-lines-demo](https://f.cloud.github.com/assets/2988/1796891/85e69ff2-6a93-11e3-89ac-31927f604592.gif)
 
+### Installation
+
+`apm install sort-lines` and restart Atom.
+
 ### Commands and Keybindings
 
 All of the following commands are under the `atom-text-editor` selector.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Sorts your lines in Atom, never gets tired.
 
 ### Installation
 
-`apm install sort-lines` and restart Atom.
+From GUI: Settings -> Install -> search for "sort-lines" and click "Install"
+
+From CLI: `apm install sort-lines` and restart Atom.
 
 ### Commands and Keybindings
 


### PR DESCRIPTION
I don't install packages super often in Atom, so when I do I need to re-look up how to install a package if the docs don't have it listed. This change puts the install instructions front and center.