### PR TITLE
Add issue and pull request templates

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--
+
+Have you read Atom's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/atom/atom/blob/master/CODE_OF_CONDUCT.md
+
+Do you want to ask a question? Are you looking for support? The Atom message board is the best place for getting support: https://discuss.atom.io
+
+-->
+
+### Description
+
+[Description of the issue]
+
+### Steps to Reproduce
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+**Expected behavior:** [What you expect to happen]
+
+**Actual behavior:** [What actually happens]
+
+**Reproduces how often:** [What percentage of the time does it reproduce?]
+
+### Versions
+
+You can get this information from copy and pasting the output of `atom --version` and `apm --version` from the command line. Also, please include the OS and what version of the OS you're running.
+
+### Additional Information
+
+Any additional information, configuration or data that might be necessary to reproduce the issue.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+### Requirements
+
+* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
+* All new code requires tests to ensure against regressions
+
+### Description of the Change
+
+<!--
+
+We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
+
+-->
+
+### Alternate Designs
+
+<!-- Explain what other alternates were considered and why the proposed version was selected -->
+
+### Why Should This Be In Core?
+
+<!-- Explain why this functionality should be in atom/atom as opposed to a package -->
+
+### Benefits
+
+<!-- What benefits will be realized by the code change? -->
+
+### Possible Drawbacks
+
+<!-- What are the possible side-effects or negative impacts of the code change? -->
+
+### Applicable Issues
+
+<!-- Enter any applicable Issues here -->


### PR DESCRIPTION
When reviewing https://github.com/atom/sort-lines/issues/76, I found myself requesting that the issue author describe the steps to reproduce the issue, and I noticed that we don't have an issue template in this repository.

This PR adds [Atom's standard pull request template](https://github.com/atom/atom/blob/4cef36e566/PULL_REQUEST_TEMPLATE.md), and _most_ of [Atom's standard issue template](https://github.com/atom/atom/blob/4cef36e566/ISSUE_TEMPLATE.md). In the issue template, I've omitted the ["prerequisites" section found in Atom's standard issue template](https://github.com/atom/atom/blob/4cef36e566/ISSUE_TEMPLATE.md#prerequisites), since the items in that section seem applicable to Atom core and to packages that come bundled with Atom. Because sort-lines doesn't come bundled with Atom, I don't think those steps are applicable to this package.


