### PR TITLE
Add shuffle command

### DIFF
--- a/lib/sort-lines.js
+++ b/lib/sort-lines.js
@@ -1,4 +1,5 @@
 const RangeFinder = require('./range-finder')
+const shuffle = require('array-shuffle')
 const naturalSort = require('javascript-natural-sort')
 
 module.exports = {
@@ -18,6 +19,9 @@ module.exports = {
       },
       'sort-lines:natural' () {
         sortLinesNatural(atom.workspace.getActiveTextEditor())
+      },
+      'sort-lines:shuffle' () {
+        shuffleLines(atom.workspace.getActiveTextEditor())
       }
     })
   }
@@ -59,5 +63,11 @@ function sortLinesInsensitive (editor) {
 function sortLinesNatural (editor) {
   sortTextLines(editor,
     (textLines) => textLines.sort(naturalSort)
+  )
+}
+
+function shuffleLines (editor) {
+  sortTextLines(editor,
+    (textLines) => Array.from(shuffle(textLines))
   )
 }

--- a/lib/sort-lines.js
+++ b/lib/sort-lines.js
@@ -68,6 +68,6 @@ function sortLinesNatural (editor) {
 
 function shuffleLines (editor) {
   sortTextLines(editor,
-    (textLines) => Array.from(shuffle(textLines))
+    (textLines) => shuffle(textLines)
   )
 }

--- a/menus/sort-lines.cson
+++ b/menus/sort-lines.cson
@@ -9,6 +9,7 @@
         { 'label': 'Unique', 'command': 'sort-lines:unique' }
         { 'label': 'Sort (Case Insensitive)', 'command': 'sort-lines:case-insensitive-sort' }
         { 'label': 'Natural', 'command': 'sort-lines:natural' }
+        { 'label': 'Shuffle', 'command': 'sort-lines:shuffle' }
       ]
     ]
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
       "sort-lines:reverse-sort",
       "sort-lines:unique",
       "sort-lines:case-insensitive-sort",
-      "sort-lines:natural"
+      "sort-lines:natural",
+      "sort-lines:shuffle"
     ]
   },
   "repository": "https://github.com/atom/sort-lines",
@@ -18,6 +19,7 @@
     "atom": ">=1.4.0 <2.0.0"
   },
   "dependencies": {
+    "array-shuffle": "^1.0.1",
     "javascript-natural-sort": "^0.7.1"
   }
 }

--- a/spec/sort-lines-spec.js
+++ b/spec/sort-lines-spec.js
@@ -22,6 +22,9 @@ describe('sorting lines', () => {
   const sortLinesNatural =
     (callback) => runCommand('sort-lines:natural', callback)
 
+  const shuffleLines =
+    (callback) => runCommand('sort-lines:shuffle', callback)
+
   beforeEach(() => {
     waitsForPromise(() => atom.workspace.open())
 
@@ -273,6 +276,29 @@ describe('sorting lines', () => {
         )
       )
     })
+    
+    describe('shuffling', () => {
+      it('shuffle lines', () => {
+        editor.setText(
+          '4a  \n' +
+          '1a  \n' +
+          '2a  \n' +
+          '12a \n' +
+          '3a  \n' +
+          '0a  \n'
+        )
+
+        shuffleLines(() =>
+          expect(editor.getText()).toNotBe(
+            '4a  \n' +
+            '1a  \n' +
+            '2a  \n' +
+            '12a \n' +
+            '3a  \n' +
+            '0a  \n'
+          )
+        )
+      })
 
     it('orders by word', () => {
       editor.setText(

--- a/spec/sort-lines-spec.js
+++ b/spec/sort-lines-spec.js
@@ -299,6 +299,8 @@ describe('sorting lines', () => {
           )
         )
       })
+    })
+
 
     it('orders by word', () => {
       editor.setText(

--- a/spec/sort-lines-spec.js
+++ b/spec/sort-lines-spec.js
@@ -276,31 +276,6 @@ describe('sorting lines', () => {
         )
       )
     })
-    
-    describe('shuffling', () => {
-      it('shuffle lines', () => {
-        editor.setText(
-          '4a  \n' +
-          '1a  \n' +
-          '2a  \n' +
-          '12a \n' +
-          '3a  \n' +
-          '0a  \n'
-        )
-
-        shuffleLines(() =>
-          expect(editor.getText()).toNotBe(
-            '4a  \n' +
-            '1a  \n' +
-            '2a  \n' +
-            '12a \n' +
-            '3a  \n' +
-            '0a  \n'
-          )
-        )
-      })
-    })
-
 
     it('orders by word', () => {
       editor.setText(
@@ -532,6 +507,30 @@ describe('sorting lines', () => {
           '$10001.01 \n' +
           '$10001.02 \n' +
           '$10002.00 \n'
+        )
+      )
+    })
+  })
+
+  describe('shuffling', () => {
+    it('shuffle lines', () => {
+      editor.setText(
+        '4a  \n' +
+        '1a  \n' +
+        '2a  \n' +
+        '12a \n' +
+        '3a  \n' +
+        '0a  \n'
+      )
+
+      shuffleLines(() =>
+        expect(editor.getText()).toNotBe(
+          '4a  \n' +
+          '1a  \n' +
+          '2a  \n' +
+          '12a \n' +
+          '3a  \n' +
+          '0a  \n'
         )
       )
     })


### PR DESCRIPTION
This pull request adds the sort-lines:shuffle command. The command shuffles an array of items in a random order using the [`array-shuffle`](https://github.com/sindresorhus/array-shuffle#readme) package. 

This feature is discussed in #24.

Not sure how I can test this. Is there a `toNotBe` method available in the test suite?