### PR TITLE
Improve clarity of menu commands

### DIFF
--- a/menus/sort-lines.cson
+++ b/menus/sort-lines.cson
@@ -5,12 +5,12 @@
       'label': 'Lines'
       'submenu': [
         { 'label': 'Sort', 'command': 'sort-lines:sort' }
-        { 'label': 'Reverse Sort', 'command': 'sort-lines:reverse-sort' }
-        { 'label': 'Unique', 'command': 'sort-lines:unique' }
-        { 'label': 'Sort (Case Insensitive)', 'command': 'sort-lines:case-insensitive-sort' }
-        { 'label': 'Natural', 'command': 'sort-lines:natural' },
-        { 'label': 'By Length', 'command': 'sort-lines:by-length' },
+        { 'label': 'Sort Ignoring Case', 'command': 'sort-lines:case-insensitive-sort' }
+        { 'label': 'Sort in Natural Order', 'command': 'sort-lines:natural' },
+        { 'label': 'Sort in Reverse', 'command': 'sort-lines:reverse-sort' }
+        { 'label': 'Sort by Length', 'command': 'sort-lines:by-length' },
         { 'label': 'Shuffle', 'command': 'sort-lines:shuffle' }
+        { 'label': 'Remove Duplicates', 'command': 'sort-lines:unique' }
       ]
     ]
   }


### PR DESCRIPTION
Prior to this change, the menu included commands like:

- Edit > Lines > Natural
- Edit > Lines > By Length

If you don't know that those commands were added by the `sort-lines` package, it's not particularly clear what those commands will do. This pull request updates the menu commands in an attempt to improve clarity.

### Before

<img width="578" alt="screen_shot_2017-10-08_at_4_02_09_pm" src="https://user-images.githubusercontent.com/2988/31320511-bf515520-ac43-11e7-8d5b-a63382aac4a9.png">

### After

<img width="579" alt="screen_shot_2017-10-08_at_4_13_36_pm" src="https://user-images.githubusercontent.com/2988/31320515-c7908de6-ac43-11e7-9ea2-be484a886437.png">
