### PR TITLE
Add case insensitive for natural sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ If any lines are selected in the active buffer, the commands operate on the sele
 |`sort-lines:sort`|Sorts the lines (case sensitive)|<kbd>F5</kbd>
 |`sort-lines:case-insensitive-sort`|Sorts the lines (case insensitive)|
 |`sort-lines:natural`|Sorts the lines (["natural" order](https://www.npmjs.com/package/javascript-natural-sort))|
+|`sort-lines:natural-case-insensitive`|Sorts the lines (["natural" order  with case insensitivity](https://www.npmjs.com/package/javascript-natural-sort#to-enable-case-insensitive-sorting))|
 |`sort-lines:reverse-sort`|Sorts the lines in reverse order (case sensitive)|
 |`sort-lines:by-length`|Sorts the lines by length|
 |`sort-lines:shuffle`|Sorts the lines in random order|

--- a/lib/sort-lines.js
+++ b/lib/sort-lines.js
@@ -20,6 +20,9 @@ module.exports = {
       'sort-lines:natural' () {
         sortLinesNatural(atom.workspace.getActiveTextEditor())
       },
+      'sort-lines:natural-case-insensitive' () {
+        sortLinesNaturalCaseInsensitive(atom.workspace.getActiveTextEditor())
+      },
       'sort-lines:by-length' () {
         sortLinesByLength(atom.workspace.getActiveTextEditor())
       },
@@ -66,6 +69,16 @@ function sortLinesInsensitive (editor) {
 function sortLinesNatural (editor) {
   sortTextLines(editor,
     (textLines) => textLines.sort(naturalSort)
+  )
+}
+
+function sortLinesNaturalCaseInsensitive (editor) {
+  sortTextLines(editor,
+    (textLines) => {
+        naturalSort.insensitive = true;
+
+        return textLines.sort(naturalSort)
+    }
   )
 }
 

--- a/menus/sort-lines.cson
+++ b/menus/sort-lines.cson
@@ -9,6 +9,7 @@
         { 'label': 'Unique', 'command': 'sort-lines:unique' }
         { 'label': 'Sort (Case Insensitive)', 'command': 'sort-lines:case-insensitive-sort' }
         { 'label': 'Natural', 'command': 'sort-lines:natural' }
+        { 'label': 'Natural (Case Insensitive)', 'command': 'sort-lines:natural-case-insensitive' }
         { 'label': 'By Length', 'command': 'sort-lines:by-length' }
         { 'label': 'Shuffle', 'command': 'sort-lines:shuffle' }
       ]

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
       "sort-lines:sort",
       "sort-lines:case-insensitive-sort",
       "sort-lines:natural",
+      "sort-lines:natural-case-insensitive",
       "sort-lines:reverse-sort",
       "sort-lines:by-length",
       "sort-lines:shuffle",

--- a/spec/sort-lines-spec.js
+++ b/spec/sort-lines-spec.js
@@ -22,6 +22,9 @@ describe('sorting lines', () => {
   const sortLinesNatural =
     (callback) => runCommand('sort-lines:natural', callback)
 
+  const sortLinesNaturalCaseInsensitive =
+    (callback) => runCommand('sort-lines:natural-insensitive', callback)
+
   const sortLinesByLength =
       (callback) => runCommand('sort-lines:by-length', callback)
 
@@ -510,6 +513,30 @@ describe('sorting lines', () => {
           '$10001.01 \n' +
           '$10001.02 \n' +
           '$10002.00 \n'
+        )
+      )
+    })
+  })
+
+  describe('natural with case insensitive sorting', () => {
+    it('sorts naturally with case insensitive sorting', () => {
+      editor.setText(
+        '2Hydrogen \n' +
+        'lithium  \n' +
+        'helium   \n' +
+        'Helium   \n' +
+        '1Helium   \n' +
+        'Lithium  \n'
+      )
+
+      sortLinesNaturalCaseInsensitive(() =>
+        expect(editor.getText()).toBe(
+          '1Helium  \n' +
+          '2Hydrogen    \n' +
+          'helium   \n' +
+          'Helium   \n' +
+          'lithium  \n' +
+          'Lithium  \n' +
         )
       )
     })


### PR DESCRIPTION
### Description of the Change

Added an option for case insensitive natural sorting. Example seen [here](https://www.npmjs.com/package/javascript-natural-sort#to-enable-case-insensitive-sorting) in their docs

### Alternate Designs

Alternate idea would be to have an option in the package preferences that changes natural sort sensitivity.

### Why Should This Be In Core?

Because natural sorting is already in core and case-insensitivity is there as well. It makes sense to provide an option for natural case insensitive

### Benefits

Option for both case insensitive + natural

### Possible Drawbacks

None that I can see