### PR TITLE
Add configuration for probot-stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,34 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 180
+# Number of days of inactivity before a stale Issue or Pull Request is closed
+daysUntilClose: 14
+# Issues or Pull Requests with these labels will never be considered stale
+exemptLabels:
+  - security
+# Label to use when marking as stale
+staleLabel: stale
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  Thanks for your contribution!
+
+  This issue has been automatically marked as stale because it has not had
+  recent activity. Because the Atom team treats their issues
+  [as their backlog](https://en.wikipedia.org/wiki/Scrum_(software_development)#Product_backlog), stale issues
+  are closed. If you would like this issue to remain open:
+
+   1. Verify that you can still reproduce the issue using the latest version of this package with the latest version of Atom
+   1. Comment that the issue is still reproducible and include:
+      * What version of the package you reproduced the issue on
+      * What version of Atom you reproduced the issue on
+      * What OS and version you reproduced the issue on
+      * What steps you followed to reproduce the issue
+
+  Issues that are labeled as triaged will not be automatically marked as stale.
+# Comment to post when removing the stale label. Set to `false` to disable
+unmarkComment: false
+# Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
+closeComment: false
+# Limit to only `issues` or `pulls`
+only: issues


### PR DESCRIPTION
Using https://github.com/atom/atom/pull/14382 as inspiration, this PR configures the [probot-stale integration](https://github.com/probot/stale) to automatically close issues that have not had any recent activity.
