### PR TITLE
Teach probot-stale to ignore issues labeled `regression` or `triaged`

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,7 +6,9 @@ daysUntilStale: 180
 daysUntilClose: 14
 # Issues or Pull Requests with these labels will never be considered stale
 exemptLabels:
+  - regression
   - security
+  - triaged
 # Label to use when marking as stale
 staleLabel: stale
 # Comment to post when marking as stale. Set to `false` to disable


### PR DESCRIPTION
This PR updates the package's probot-stale configuration to use the same [set of exempt labels that we use for atom/atom](https://github.com/atom/atom/blob/4eea63c50b4f8061f633392bf581e3d3a4fb3e5b/.github/stale.yml#L8-L11).

/xref https://github.com/atom/sort-lines/pull/88#pullrequestreview-72708614
/cc @Ben3eeE for review