### PR TITLE
Add case-sensitivity tests for documentation purposes

### DIFF
--- a/spec/sort-lines-spec.js
+++ b/spec/sort-lines-spec.js
@@ -235,6 +235,24 @@ describe('sorting lines', () => {
     })
   })
 
+  describe('case-sensitive sorting (the default)', () =>
+    it('sorts all lines, case sensitive', () => {
+      editor.setText(
+        'helium   \n' +
+        'Helium   \n' +
+        'helium   \n'
+      )
+
+      sortLines(() =>
+        expect(editor.getText()).toBe(
+          'helium   \n' +
+          'helium   \n' +
+          'Helium   \n'
+        )
+      )
+    })
+  )
+
   describe('case-insensitive sorting', () =>
     it('sorts all lines, ignoring case', () => {
       editor.setText(
@@ -242,6 +260,7 @@ describe('sorting lines', () => {
         'lithium  \n' +
         'helium   \n' +
         'Helium   \n' +
+        'helium   \n' +
         'Lithium  \n'
       )
 
@@ -249,6 +268,7 @@ describe('sorting lines', () => {
         expect(editor.getText()).toBe(
           'helium   \n' +
           'Helium   \n' +
+          'helium   \n' +
           'Hydrogen \n' +
           'lithium  \n' +
           'Lithium  \n'


### PR DESCRIPTION
### Description of the Change

Adds tests to ensure that case-sensitivity is working as expected and documents those expectations. For the record, we are using _locale-specific_ case sensitivity as the default. This does mean that different machines or potentially even different users on the same machine will sort lines differently using the default sort. If people want something more deterministic, they may want to use "natural" sorting.

Locale-specific comparisons on my machine (us-en):

* `a` < `A`
* `a` < `b`
* `A` < `b`
* `A` < `B`

This means that `aardvark` will sort before `Aardvark` and that `Aardvark` will sort before `bear`. This means that the following series:

```
aardvark
Aardvark
bear
```

when subjected to both case-sensitive and case-insensitive sorting, will not have its order changed. But this series:

```
Aardvark
aardvark
bear
```

will have its order changed by the default case-sensitive sort while the case-insensitive sort will not.

### Alternate Designs

We could choose a different default. I believe that using locale-specific sorting will be the most commonly-expected.

### Benefits

Document what "case-sensitivity" means.

### Possible Drawbacks

N/A

### Applicable Issues

Fixes #33