### PR TITLE
Adds 'sort-lines:by-length-reversed' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ If any lines are selected in the active buffer, the commands operate on the sele
 |`sort-lines:natural`|Sorts the lines (["natural" order](https://www.npmjs.com/package/javascript-natural-sort))|
 |`sort-lines:reverse-sort`|Sorts the lines in reverse order (case sensitive)|
 |`sort-lines:by-length`|Sorts the lines by length|
+|`sort-lines:by-length-reversed`|Sorts the lines by length in reverse order|
 |`sort-lines:shuffle`|Sorts the lines in random order|
 |`sort-lines:unique`|Removes duplicate lines|
 

--- a/lib/sort-lines.js
+++ b/lib/sort-lines.js
@@ -23,6 +23,9 @@ module.exports = {
       'sort-lines:by-length' () {
         sortLinesByLength(atom.workspace.getActiveTextEditor())
       },
+      'sort-lines:by-length-reversed' () {
+        sortLinesByLengthReversed(atom.workspace.getActiveTextEditor())
+      },
       'sort-lines:shuffle' () {
         shuffleLines(atom.workspace.getActiveTextEditor())
       }
@@ -72,6 +75,12 @@ function sortLinesNatural (editor) {
 function sortLinesByLength (editor) {
   sortTextLines(editor,
     (textLines) => textLines.sort((a, b) => a.length - b.length)
+  )
+}
+
+function sortLinesByLengthReversed (editor) {
+  sortTextLines(editor,
+    (textLines) => textLines.sort((a, b) => b.length - a.length)
   )
 }
 

--- a/menus/sort-lines.cson
+++ b/menus/sort-lines.cson
@@ -9,6 +9,7 @@
         { 'label': 'Sort in Natural Order', 'command': 'sort-lines:natural' }
         { 'label': 'Sort in Reverse', 'command': 'sort-lines:reverse-sort' }
         { 'label': 'Sort by Length', 'command': 'sort-lines:by-length' }
+        { 'label': 'Sort by Length in Reverse', 'command': 'sort-lines:by-length-reversed' }
         { 'label': 'Shuffle', 'command': 'sort-lines:shuffle' }
         { 'label': 'Remove Duplicates', 'command': 'sort-lines:unique' }
       ]

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
       "sort-lines:natural",
       "sort-lines:reverse-sort",
       "sort-lines:by-length",
+      "sort-lines:by-length-reversed",
       "sort-lines:shuffle",
       "sort-lines:unique"
     ]

--- a/spec/sort-lines-spec.js
+++ b/spec/sort-lines-spec.js
@@ -25,6 +25,9 @@ describe('sorting lines', () => {
   const sortLinesByLength =
       (callback) => runCommand('sort-lines:by-length', callback)
 
+  const sortLinesByLengthReversed =
+      (callback) => runCommand('sort-lines:by-length-reversed', callback)
+
   const shuffleLines =
     (callback) => runCommand('sort-lines:shuffle', callback)
 
@@ -552,6 +555,28 @@ describe('sorting lines', () => {
           'Lithium\n' +
           'Hydrogen\n' +
           'Beryllium\n'
+        )
+      )
+    })
+  })
+
+  describe('sorting by length reverse', () => {
+    it('sorts the lines by length in reverse order', () => {
+      editor.setText(
+        'Hydrogen\n' +
+        'Helium\n' +
+        'Lithium\n' +
+        'Beryllium\n' +
+        'Boron\n'
+      )
+
+      sortLinesByLengthReversed(() =>
+        expect(editor.getText()).toBe(
+          'Beryllium\n' +
+          'Hydrogen\n' +
+          'Lithium\n' +
+          'Helium\n' +
+          'Boron\n'
         )
       )
     })


### PR DESCRIPTION
### Description of the Change

Simply adds a reversed version of `sort-lines:by-length`.

### Alternate Designs

I wasn't sure whether to call the new function `sort-lines:by-length-reversed` or `sort-lines:reversed-by-length`, so I chose the former since it sounded more natural.

I also considered `sort-lines:by-length-descending`, but I felt that necessitated changing `sort-lines:by-length` to `sort-lines:by-length-ascending`, which I assume is undesirable.

### Benefits

You can sort by line, but in reverse!

### Possible Drawbacks

None!

### Applicable Issues

None!
