### PR TITLE
Removes debug statements introduced in 01111c7

### DIFF
--- a/spec/sort-lines-spec.js
+++ b/spec/sort-lines-spec.js
@@ -570,8 +570,6 @@ describe('sorting lines', () => {
 
       shuffleLines(() => {
         const shuffledText = editor.getText()
-        console.log(originalText);
-        console.log(shuffledText);
         expect(shuffledText.split('\n').length).toEqual(originalText.split('\n').length)
         expect(shuffledText).toNotBe(originalText)
       })


### PR DESCRIPTION
### Description of the Change

This is a pedantic change that removes debug statements introduced by @jasonrudolph in 01111c7 (presumably by accident?)

### Alternate Designs

If these lines are intentional, then the semicolons should probably be removed to match the style of the rest of the repo.

### Benefits

Consistent code style.

### Possible Drawbacks

None!

### Applicable Issues

None!
