### PR TITLE
Dispose of disposables on deactivation

### DIFF
--- a/lib/sort-lines.js
+++ b/lib/sort-lines.js
@@ -4,7 +4,7 @@ const naturalSort = require('javascript-natural-sort')
 
 module.exports = {
   activate () {
-    atom.commands.add('atom-text-editor:not([mini])', {
+    this.commandsDisposable = atom.commands.add('atom-text-editor:not([mini])', {
       'sort-lines:sort' () {
         sortLines(atom.workspace.getActiveTextEditor())
       },
@@ -27,6 +27,10 @@ module.exports = {
         shuffleLines(atom.workspace.getActiveTextEditor())
       }
     })
+  },
+
+  deactivate () {
+    this.commandsDisposable.dispose()
   }
 }
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Dispose of any added commands on deactivation.  Prevents commands from appearing in the Command Palette and working even after package deactivation.

Test plan (because I know you like these :wink:):
1. `sort-lines:sort`
2. Disable package
3. Attempt to `sort-lines:sort` (command should not exist in Command Palette with this PR)

### Alternate Designs

None.

### Benefits

Proper package deactivation.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #92

/cc @jasonrudolph