### PR TITLE
Added reverse command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If any lines are selected in the active buffer, the commands operate on the sele
 |`sort-lines:reverse-sort`|Sorts the lines in reverse order (case sensitive)|
 |`sort-lines:by-length`|Sorts the lines by length|
 |`sort-lines:shuffle`|Sorts the lines in random order|
+|`sort-lines:reverse`|Reverse lines in current order|
 |`sort-lines:unique`|Removes duplicate lines|
 
 Custom keybindings can be added by referencing the above commands.  To learn more, visit the [Using Atom: Basic Customization](http://flight-manual.atom.io/using-atom/sections/basic-customization/#customizing-keybindings) or [Behind Atom: Keymaps In-Depth](http://flight-manual.atom.io/behind-atom/sections/keymaps-in-depth) sections in the flight manual.

--- a/lib/sort-lines.js
+++ b/lib/sort-lines.js
@@ -25,7 +25,10 @@ module.exports = {
       },
       'sort-lines:shuffle' () {
         shuffleLines(atom.workspace.getActiveTextEditor())
-      }
+      },
+      'sort-lines:reverse' () {
+        reversedLines(atom.workspace.getActiveTextEditor())
+      },
     })
   },
 
@@ -82,5 +85,11 @@ function sortLinesByLength (editor) {
 function shuffleLines (editor) {
   sortTextLines(editor,
     (textLines) => shuffle(textLines)
+  )
+}
+
+function reversedLines (editor) {
+  sortTextLines(editor,
+    (textLines) => textLines.reverse()
   )
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
       "sort-lines:reverse-sort",
       "sort-lines:by-length",
       "sort-lines:shuffle",
+      "sort-lines:reverse",
       "sort-lines:unique"
     ]
   },

--- a/spec/sort-lines-spec.js
+++ b/spec/sort-lines-spec.js
@@ -27,6 +27,9 @@ describe('sorting lines', () => {
 
   const shuffleLines =
     (callback) => runCommand('sort-lines:shuffle', callback)
+    
+  const reverseLines =
+    (callback) => runCommand('sort-lines:reverse', callback)
 
   beforeEach(() => {
     waitsForPromise(() => atom.workspace.open())
@@ -575,4 +578,22 @@ describe('sorting lines', () => {
       })
     })
   })
+  
+  describe('reversed sorting', () =>
+    it('reverse lines in current order', () => {
+      editor.setText(
+        'Hydrogen \n' +
+        'Helium   \n' +
+        'Lithium  \n'
+      )
+
+      reverseLines(() =>
+        expect(editor.getText()).toBe(
+          'Lithium  \n' +
+          'Helium   \n' + 
+          'Hydrogen \n' 
+        )
+      )
+    })
+  )
 })


### PR DESCRIPTION
### Description of the Change

This pull request adds support to reverse lines in the current order without sorting them.

Input:
```
1
3
2
```
Output:
```
2
3
1
```

### Alternate Designs

N/A

### Benefits

N/A

### Possible Drawbacks

Not sure about the naming of the commands. Having two commands with the word reverse might not be the best choice. Maybe we should rename the sort command to `Sort Ascending` and `Sort Descending`?

### Applicable Issues

Closes #20
