### PR TITLE
📝 Provide recipe for custom sorting combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,34 @@ If any lines are selected in the active buffer, the commands operate on the sele
 |`sort-lines:unique`|Removes duplicate lines|
 
 Custom keybindings can be added by referencing the above commands.  To learn more, visit the [Using Atom: Basic Customization](http://flight-manual.atom.io/using-atom/sections/basic-customization/#customizing-keybindings) or [Behind Atom: Keymaps In-Depth](http://flight-manual.atom.io/behind-atom/sections/keymaps-in-depth) sections in the flight manual.
+
+### [Optional] Custom sorting combinations
+
+Each command above provides an *individual* type of sorting operation. If you find yourself frequently performing multiple types of sorts back-to-back, you can optionally define a command to perform all those sorts at once. For example, if you want to perform a case-insensitive reverse sort, you can first run the `sort-lines:case-insensitive-sort` command followed by the `sort-lines:reverse` command, or you can define a custom [composed command](https://blog.atom.io/2018/10/09/automate-repetitive-tasks-with-composed-commands.html) that performs both of these operations for you.
+
+You can define these custom commands in your [init file](https://flight-manual.atom.io/hacking-atom/sections/the-init-file/#the-init-file). (You can read more about customizing your init file in the [flight manual](https://flight-manual.atom.io/hacking-atom/sections/the-init-file/#the-init-file).) If your init file is named `init.coffee`, refer to the `init.coffee` example below. If your init file is named `init.js`, refer to the `init.js` example below.
+
+#### `init.coffee` example
+
+```coffeescript
+# Perform a case-insensitive reverse sort of the selected lines (or all lines in
+# the file if no lines are selected)
+atom.commands.add 'atom-text-editor:not([mini])', 'me:case-insensitive-reverse-sort', ->
+  editor = atom.workspace.getActiveTextEditor()
+  editorView = atom.views.getView(editor)
+  atom.commands.dispatch editorView, 'sort-lines:case-insensitive-sort'
+  .then () -> atom.commands.dispatch editorView, 'sort-lines:reverse'
+```
+
+#### `init.js` example
+
+```js
+// Perform a case-insensitive reverse sort of the selected lines (or all lines
+// in the file if no lines are selected)
+atom.commands.add('atom-text-editor:not([mini])', 'me:case-insensitive-reverse-sort', async () => {
+  const editor = atom.workspace.getActiveTextEditor()
+  const editorView = atom.views.getView(editor)
+  await atom.commands.dispatch(editorView, 'sort-lines:case-insensitive-sort')
+  await atom.commands.dispatch(editorView, 'sort-lines:reverse')
+})
+```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ If any lines are selected in the active buffer, the commands operate on the sele
 |`sort-lines:sort`|Sorts the lines (case sensitive)|<kbd>F5</kbd>
 |`sort-lines:case-insensitive-sort`|Sorts the lines (case insensitive)|
 |`sort-lines:natural`|Sorts the lines (["natural" order](https://www.npmjs.com/package/javascript-natural-sort))|
-|`sort-lines:reverse-sort`|Sorts the lines in reverse order (case sensitive)|
 |`sort-lines:by-length`|Sorts the lines by length|
 |`sort-lines:shuffle`|Sorts the lines in random order|
 |`sort-lines:reverse`|Reverses *current* order of the lines|

--- a/menus/sort-lines.cson
+++ b/menus/sort-lines.cson
@@ -7,7 +7,7 @@
         { 'label': 'Sort', 'command': 'sort-lines:sort' }
         { 'label': 'Sort Ignoring Case', 'command': 'sort-lines:case-insensitive-sort' }
         { 'label': 'Sort in Natural Order', 'command': 'sort-lines:natural' }
-        { 'label': 'Sort in Reverse', 'command': 'sort-lines:reverse-sort' }
+        { 'label': 'Sort in Reverse [deprecated]', 'command': 'sort-lines:reverse-sort' }
         { 'label': 'Sort by Length', 'command': 'sort-lines:by-length' }
         { 'label': 'Reverse Current Order', 'command': 'sort-lines:reverse' }
         { 'label': 'Shuffle', 'command': 'sort-lines:shuffle' }


### PR DESCRIPTION
### Background

sort-lines currently provides commands for numerous types of sorting (e.g., case-sensitive, case-insensitive, natural, by length). From time to time, we've seen request for adding an "in reverse" variant of these commands. For example, in #86, we discussed the merits of adding an "in reverse" variant of the `sort-lines:natural` command. Along the way, we noted that adding an "in reverse" variant of every sorting option would risk cluttering up the UI and making it harder to find the sorting option you're looking for:

![screenshot](https://user-images.githubusercontent.com/2988/31667599-e295f1c2-b31d-11e7-9f04-2a1dbd829979.png)

Instead of providing an "in reverse" variant of each individual sorting option, I [proposed](https://github.com/atom/sort-lines/issues/86#issuecomment-337238108) that we'd be better served by providing a command to reverse the current order, regardless of what the current order is. People could then combine that command with any of the sorting commands as desired. For example, you could use the "sort in natural order" command followed by the "reverse current order" command to get the lines sorted in reverse natural order.

https://github.com/atom/sort-lines/pull/102 implemented the `sort-lines:reverse` command to reverse the current order. (Nice! :zap:)

### Let's make it easier for people to define commands that perform custom sorting combinations

If we're going to recommend using custom commands to perform various sorting combos, it seems like it would be helpful to offer some examples to help people get started. This pull request adds a section to the README to do exactly this. 😁
